### PR TITLE
Add seq column to replicas table

### DIFF
--- a/src/main/java/kmql/table/ReplicasTable.java
+++ b/src/main/java/kmql/table/ReplicasTable.java
@@ -30,14 +30,14 @@ public class ReplicasTable implements Table {
                          + "is_leader BOOLEAN NOT NULL,"
                          + "is_preferred_leader BOOLEAN NOT NULL,"
                          + "is_in_sync BOOLEAN NOT NULL,"
-                         + "seq INT NOT NULL,"
+                         + "replica_order INT NOT NULL,"
                          + "PRIMARY KEY (topic, partition, broker_id))");
         }
 
         Set<String> topics = adminClient.listTopics().names().get();
         Map<String, TopicDescription> topicInfo = adminClient.describeTopics(topics).all().get();
         try (PreparedStatement stmt = connection.prepareStatement(
-                "INSERT INTO replicas (topic, partition, broker_id, is_leader, is_preferred_leader, is_in_sync, seq)"
+                "INSERT INTO replicas (topic, partition, broker_id, is_leader, is_preferred_leader, is_in_sync, replica_order)"
                 + "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
             for (String topic : topics) {
                 TopicDescription desc = topicInfo.get(topic);

--- a/src/main/java/kmql/table/ReplicasTable.java
+++ b/src/main/java/kmql/table/ReplicasTable.java
@@ -30,25 +30,28 @@ public class ReplicasTable implements Table {
                          + "is_leader BOOLEAN NOT NULL,"
                          + "is_preferred_leader BOOLEAN NOT NULL,"
                          + "is_in_sync BOOLEAN NOT NULL,"
+                         + "seq INT NOT NULL,"
                          + "PRIMARY KEY (topic, partition, broker_id))");
         }
 
         Set<String> topics = adminClient.listTopics().names().get();
         Map<String, TopicDescription> topicInfo = adminClient.describeTopics(topics).all().get();
         try (PreparedStatement stmt = connection.prepareStatement(
-                "INSERT INTO replicas (topic, partition, broker_id, is_leader, is_preferred_leader, is_in_sync)"
-                + "VALUES (?, ?, ?, ?, ?, ?)")) {
+                "INSERT INTO replicas (topic, partition, broker_id, is_leader, is_preferred_leader, is_in_sync, seq)"
+                + "VALUES (?, ?, ?, ?, ?, ?, ?)")) {
             for (String topic : topics) {
                 TopicDescription desc = topicInfo.get(topic);
                 for (TopicPartitionInfo partition : desc.partitions()) {
                     List<Node> replicas = partition.replicas();
-                    for (Node replica : replicas) {
+                    for (int i = 0; i < replicas.size(); i++) {
+                        Node replica = replicas.get(i);
                         stmt.setString(1, topic);
                         stmt.setInt(2, partition.partition());
                         stmt.setInt(3, replica.id());
                         stmt.setBoolean(4, partition.leader().id() == replica.id());
                         stmt.setBoolean(5, replicas.get(0).id() == replica.id());
                         stmt.setBoolean(6, partition.isr().contains(replica));
+                        stmt.setInt(7, i);
                         stmt.executeUpdate();
                     }
                 }


### PR DESCRIPTION
## Motivation
- Since Kafka elects new leader in order of replicas when current leader fails, replica order is useful for investigation
  * To guess which replica was elected as new leader at incidental time

## Changes
- Add `seq` column to replicas table, which indicates the order in replicas